### PR TITLE
add gh page publish workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: docs
+
+on:
+  push
+
+jobs:
+  build_docs:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up  python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+
+    - name: install dependencies
+      run: pip install -r ./docs/requirements.txt
+
+    - name: create slides
+      run: jupyter nbconvert --to slides --output-dir docs/source/_static "notebooks/*.ipynb"
+
+    - name: convert md to rst # md reference is not recognized with md_include
+      uses: docker://pandoc/core:latest
+      with:
+        args: --from=markdown --to=rst --output=docs/source/README.rst README.md
+
+    - name: build docs
+      run: |
+        sphinx-build -W -b html docs/source docs/build -j auto
+
+    - name: deploy docs only if it is pushed to main
+      uses: peaceiris/actions-gh-pages@v3
+      # publish every time there's a push to 2023 branch
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/2023' }}
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/build
+        force_orphan: true

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+pydata-sphinx-theme
+sphinx
+jupyter

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,39 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "OospCpp"
+copyright = "2023, Matthias Möller"
+author = "Matthias Möller"
+release = "2023"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".txt": "markdown",
+    ".md": "markdown",
+}
+
+extensions = [
+]
+
+
+templates_path = ["_templates"]
+exclude_patterns = []
+
+pygments_style = "sphinx"
+
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme = "pydata_sphinx_theme"
+html_title  = "OospCpp"
+html_static_path = ["_static"]
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,16 @@
+.. include:: README.rst
+
+
+Static Lecture Notes
+--------------------
+*  `Lecture 1: Basics <_static/lecture1.slides.html>`_
+
+References
+----------
+.. toctree::
+   :maxdepth: 1
+
+   Github <https://github.com/mmoelle1/OospCpp>
+
+
+


### PR DESCRIPTION
Adds github workflow to automate doc generation with the following steps:
1. install requirements
2. generate slides
3. convert readme.md to .rst (usually, sphinx can process markdown, but was having some issues with references)
4. generate docs using sphinx
5. publish